### PR TITLE
fix(helm): add `urls.scotty` property to configuration

### DIFF
--- a/helm/swingletree/templates/_config.tpl
+++ b/helm/swingletree/templates/_config.tpl
@@ -1,4 +1,6 @@
 {{- define "swingletree.config" -}}
+urls:
+  scotty: "http://swing-scotty.{{ .Release.Namespace }}:3000"
 deck:
   path: {{ .Values.deck.path }}
   elastic:


### PR DESCRIPTION
### Description

Gate is missing the configuration property `urls.scotty` when deployed using the helm chart
